### PR TITLE
Fix missing endset

### DIFF
--- a/resources/syntax/Twig.sublime-syntax
+++ b/resources/syntax/Twig.sublime-syntax
@@ -28,7 +28,7 @@ variables:
   end_tags: |-
     (?x:
       \b(?:
-        endblock|endfor|endmacro|endif|endwith|endautoescape|endapply|endembed
+        endblock|endset|endfor|endmacro|endif|endwith|endautoescape|endapply|endembed
         |endsandbox|endcache
       )\b
     )

--- a/resources/syntax/tests/syntax/syntax_test_statements.twig
+++ b/resources/syntax/tests/syntax/syntax_test_statements.twig
@@ -117,6 +117,16 @@
 ##                  ^ keyword.operator.assignment.twig
 ##                    ^^^^^^^^^^^^^^ meta.string.twig string.quoted.double.twig
 
+    {% set %} {% endset %}
+##  ^^^^^^^^^ meta.statement.twig
+##            ^^^^^^^^^^^^ meta.statement.twig
+##  ^^ punctuation.definition.statement.begin.twig
+##         ^^ punctuation.definition.statement.end.twig
+##            ^^ punctuation.definition.statement.begin.twig
+##                      ^^ punctuation.definition.statement.end.twig
+##     ^^^ keyword.other.tag.twig
+##               ^^^^^^ keyword.other.endtag.twig
+
     {% extends "template.twig" %}
 ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.twig
 ##  ^^ punctuation.definition.statement.begin.twig


### PR DESCRIPTION
The set tag can also be used to 'capture' chunks of text: https://twig.symfony.com/doc/3.x/tags/set.html. The syntax currently doesn't capture `endset`.