### PR TITLE
Improvements: support filters, object properties

### DIFF
--- a/.github/workflows/syntax_test.yml
+++ b/.github/workflows/syntax_test.yml
@@ -51,10 +51,10 @@ jobs:
           tar xf st_syntax_tests.tar.xz
           mv st_syntax_tests/* ./
           rm -R st_syntax_tests st_syntax_tests.tar.xz
-      - name: Move root dirs & files into "Data/Packages/BetterTwig" subdir (except for syntax_tests)
+      - name: Move root dirs & files into "Data/Packages/Twig" subdir (except for syntax_tests)
         run: |
-          mkdir -p Data/Packages/BetterTwig
-          find . -maxdepth 1 -mindepth 1 -not -name 'Data' \! -name 'syntax_tests' -exec mv '{}' Data/Packages/BetterTwig ';'
+          mkdir -p Data/Packages/Twig
+          find . -maxdepth 1 -mindepth 1 -not -name 'Data' \! -name 'syntax_tests' -exec mv '{}' Data/Packages/Twig ';'
       - name: Download HTML & other extending syntaxes and move it to Data/Packages
         run: |
           wget -O HTML.sublime-syntax https://raw.githubusercontent.com/sublimehq/Packages/master/HTML/HTML.sublime-syntax

--- a/resources/syntax/Twig.sublime-syntax
+++ b/resources/syntax/Twig.sublime-syntax
@@ -289,6 +289,7 @@ contexts:
     - match: \.
       scope: punctuation.accessor.dot.twig
       push:
+        - include: functions
         - match: '{{identifiers}}'
           scope: meta.property.object.twig
         - include: immediately_pop

--- a/resources/syntax/Twig.sublime-syntax
+++ b/resources/syntax/Twig.sublime-syntax
@@ -502,6 +502,12 @@ contexts:
       scope: keyword.operator.ternary.twig
     - match: \|
       scope: keyword.operator.logical.pipe.twig
+      push:
+        - include: builtin_functions
+        - include: functions
+        - match: '{{identifiers}}+(?=\b)'
+          scope: variable.function.filter.twig
+        - include: immediately_pop
     - match: \~
       scope: keyword.operator.concatenation.twig
     - match: \={2}

--- a/resources/syntax/Twig.sublime-syntax
+++ b/resources/syntax/Twig.sublime-syntax
@@ -288,6 +288,10 @@ contexts:
   dot_accessor:
     - match: \.
       scope: punctuation.accessor.dot.twig
+      push:
+        - match: '{{identifiers}}'
+          scope: meta.property.object.twig
+        - include: immediately_pop
 
   builtin_functions:
     - match: ({{builtin_functions}})(\()

--- a/resources/syntax/tests/indentation/syntax_test_indentation.twig
+++ b/resources/syntax/tests/indentation/syntax_test_indentation.twig
@@ -1,4 +1,4 @@
-## SYNTAX TEST reindent "Packages/BetterTwig/resources/syntax/HTML (Twig).sublime-syntax"
+## SYNTAX TEST reindent "Packages/Twig/resources/syntax/HTML (Twig).sublime-syntax"
 
 {# Tags #}
 

--- a/resources/syntax/tests/syntax/syntax_test_builtin_functions.twig
+++ b/resources/syntax/tests/syntax/syntax_test_builtin_functions.twig
@@ -1,4 +1,4 @@
-## SYNTAX TEST "Packages/BetterTwig/resources/syntax/HTML (Twig).sublime-syntax"
+## SYNTAX TEST "Packages/Twig/resources/syntax/HTML (Twig).sublime-syntax"
 
     {{ attribute(object, method) is defined ? 'Method exists' : 'Method does not exist' }}
 ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.placeholder.twig

--- a/resources/syntax/tests/syntax/syntax_test_builtin_tests.twig
+++ b/resources/syntax/tests/syntax/syntax_test_builtin_tests.twig
@@ -1,4 +1,4 @@
-## SYNTAX TEST "Packages/BetterTwig/resources/syntax/HTML (Twig).sublime-syntax"
+## SYNTAX TEST "Packages/Twig/resources/syntax/HTML (Twig).sublime-syntax"
 
    {% if post.status is constant('Post::PUBLISHED') %}
 ## ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.twig

--- a/resources/syntax/tests/syntax/syntax_test_comments.twig
+++ b/resources/syntax/tests/syntax/syntax_test_comments.twig
@@ -1,6 +1,6 @@
-## SYNTAX TEST "Packages/BetterTwig/resources/syntax/HTML (Twig).sublime-syntax"
+## SYNTAX TEST "Packages/Twig/resources/syntax/HTML (Twig).sublime-syntax"
 
-   
+
 ## <- text.html.twig
 
    {# #}

--- a/resources/syntax/tests/syntax/syntax_test_expressions.twig
+++ b/resources/syntax/tests/syntax/syntax_test_expressions.twig
@@ -1,4 +1,4 @@
-## SYNTAX TEST "Packages/BetterTwig/resources/syntax/HTML (Twig).sublime-syntax"
+## SYNTAX TEST "Packages/Twig/resources/syntax/HTML (Twig).sublime-syntax"
 
     {{  }}
 ##  ^^^^^^ meta.placeholder.twig
@@ -141,7 +141,7 @@
     {{ { == >= <= != > < } }}
 ##  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.placeholder.twig
 ##  ^^ punctuation.definition.placeholder.begin.twig
-##                         ^^ punctuation.definition.placeholder.end.twig            
+##                         ^^ punctuation.definition.placeholder.end.twig
 ##     ^^^^^^^^^^^^^^^^^^^ meta.mapping.twig
 ##     ^ punctuation.section.mapping.begin.twig
 ##                       ^ punctuation.section.mapping.end.twig
@@ -226,7 +226,7 @@
 ##           ^ punctuation.section.interpolation.begin.twig
 ##               ^ punctuation.section.interpolation.end.twig
 ##            ^^^ text.embedded.twig variable.other.twig
-   
+
     {{ "foo #{1 + 2.3} baz" }}
 ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.placeholder.twig
 ##  ^^ punctuation.definition.placeholder.begin.twig

--- a/resources/syntax/tests/syntax/syntax_test_expressions.twig
+++ b/resources/syntax/tests/syntax/syntax_test_expressions.twig
@@ -248,7 +248,7 @@
 ##  ^^ punctuation.definition.placeholder.begin.twig
 ##             ^^ punctuation.definition.placeholder.end.twig
 ##     ^^^ variable.other.twig
-##         ^^^ variable.other.twig
+##         ^^^ meta.property.object.twig
 ##        ^ punctuation.accessor.dot.twig
 
     {{ foo ? 'yes' : 'no' }}

--- a/resources/syntax/tests/syntax/syntax_test_filters.twig
+++ b/resources/syntax/tests/syntax/syntax_test_filters.twig
@@ -1,0 +1,20 @@
+## SYNTAX TEST "Packages/Twig/resources/syntax/HTML (Twig).sublime-syntax"
+
+    {{ 'value'|count }}
+##  ^^^^^^^^^^^^^^^^^^^ meta.placeholder.twig
+##  ^^ punctuation.definition.placeholder.begin.twig
+##                   ^^ meta.placeholder.twig punctuation.definition.placeholder.end.twig
+##            ^ keyword.operator.logical.pipe.twig
+##             ^^^^^ variable.function.filter.twig
+    {{ 'value'|count_filter}}
+##             ^^^^^^^^^^^^ variable.function.filter.twig
+##                           ^ - meta.placeholder.twig
+
+    {{ 'value'|default(null) }}
+##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.placeholder.twig
+##  ^^ punctuation.definition.placeholder.begin.twig
+##                           ^^ meta.placeholder.twig punctuation.definition.placeholder.end.twig
+##            ^ keyword.operator.logical.pipe.twig
+##             ^^^^^^^ - variable.function.filter.twig
+##             ^^^^^^^ variable.function.twig
+##                     ^^^^ meta.function-call.arguments.twig

--- a/resources/syntax/tests/syntax/syntax_test_imports.twig
+++ b/resources/syntax/tests/syntax/syntax_test_imports.twig
@@ -1,4 +1,4 @@
-## SYNTAX TEST "Packages/BetterTwig/resources/syntax/HTML (Twig).sublime-syntax"
+## SYNTAX TEST "Packages/Twig/resources/syntax/HTML (Twig).sublime-syntax"
 
     {% import "forms.html" as forms %}
 ##  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.twig

--- a/resources/syntax/tests/syntax/syntax_test_statements.twig
+++ b/resources/syntax/tests/syntax/syntax_test_statements.twig
@@ -1,4 +1,4 @@
-## SYNTAX TEST "Packages/BetterTwig/resources/syntax/HTML (Twig).sublime-syntax"
+## SYNTAX TEST "Packages/Twig/resources/syntax/HTML (Twig).sublime-syntax"
 
     {%  %}
 ##  ^^^^^^ meta.statement.twig
@@ -139,8 +139,8 @@
 ##  ^^ punctuation.definition.statement.begin.twig
 ##                                           ^^ punctuation.definition.statement.end.twig
 ##             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.array.twig
-##              ^ meta.string.twig string.quoted.double.twig 
-##                         ^ meta.string.twig string.quoted.double.twig 
+##              ^ meta.string.twig string.quoted.double.twig
+##                         ^ meta.string.twig string.quoted.double.twig
 ##                          ^ punctuation.separator.sequence.twig
 
     {% false true none null %}


### PR DESCRIPTION
This PR adds basic understanding of [filters](https://twig.symfony.com/doc/3.x/) like [|length](https://twig.symfony.com/doc/3.x/filters/length.html), and [|default()](https://twig.symfony.com/doc/3.x/filters/default.html).

Additionally the scope for an object's property, e.g. `object.property` is changed from `variable.other` to `meta.property.object`. This matches for instance the default JS and TS syntaxes.

Finally, the package is published as "Twig" not "BetterTwig", meaning it will be installed (via package manager) at the "Packages/Twig" path. When working on packages it's best to match that path, because it matters for tests, settings files, etc.