### PR TITLE
Allow spaces around pipes in filters

### DIFF
--- a/resources/syntax/Twig.sublime-syntax
+++ b/resources/syntax/Twig.sublime-syntax
@@ -207,8 +207,9 @@ contexts:
 ###[ Filters ]#################################################################
 
   filter:
-    - match: \|
-      scope: keyword.operator.pipe.twig
+    - match: \s*(\|)\s*
+      captures:
+        1: keyword.operator.pipe.twig
       push: filter_body
 
   filter_body:

--- a/resources/syntax/tests/syntax_test_html.twig
+++ b/resources/syntax/tests/syntax_test_html.twig
@@ -72,6 +72,27 @@
 |                 ^ - meta.function-call.arguments.twig
 |                 ^ - meta.function.filter.twig
 
+{{ name | striptags | title }}
+|  ^^^^ variable.other.twig
+|       ^^^^^^^^^^^^^^^^^^^ meta.function.filter.twig
+|                          ^ - meta.function.filter.twig
+|       ^ keyword.operator.pipe.twig
+|         ^^^^^^^^^ support.function.filter.twig
+|                   ^ keyword.operator.pipe.twig
+|                     ^^^^^ support.function.filter.twig
+
+{{ list | join(', ') }}
+|  ^^^^ variable.other.twig
+|       ^^^^^^ meta.function.filter.twig
+|             ^^^^^^ meta.group.twig meta.function-call.arguments.twig
+|            ^ - meta.group.twig
+|            ^ - meta.function-call.arguments.twig
+|             ^ punctuation.section.group.begin.twig
+|              ^^^^ meta.string.twig string.quoted.single.twig
+|                  ^ punctuation.section.group.end.twig
+|                   ^ - meta.function-call.arguments.twig
+|                   ^ - meta.function.filter.twig
+
 {% apply upper %}
 |  ^^^^^^^^^^^ meta.statement.apply.twig
 |  ^^^^^ keyword.control.twig


### PR DESCRIPTION
Twig allows the pipes used for filter calls to have spaces around them:

```twig
{{ name | striptags | title }}
```