### PR TITLE
Add common scope

### DIFF
--- a/resources/keymaps/Default.sublime-keymap
+++ b/resources/keymaps/Default.sublime-keymap
@@ -10,7 +10,7 @@
             "contents": "% ${0} %"
         },
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.html.twig - meta.string - comment" },
+            { "key": "selector", "operator": "equal", "operand": "meta.template.twig - meta.string - comment" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "{$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "}$", "match_all": true },
@@ -28,7 +28,7 @@
             "contents": "{ ${0} }"
         },
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.html.twig - meta.string - comment" },
+            { "key": "selector", "operator": "equal", "operand": "meta.template.twig - meta.string - comment" },
             { "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
             { "key": "preceding_text", "operator": "regex_contains", "operand": "{$", "match_all": true },
             { "key": "following_text", "operator": "regex_contains", "operand": "}$", "match_all": true },
@@ -46,7 +46,7 @@
             "contents": "#{${0}}"
         },
         "context": [
-            { "key": "selector", "operator": "equal", "operand": "text.html.twig & meta.string" },
+            { "key": "selector", "operator": "equal", "operand": "meta.template.twig & meta.string" },
         ],
     },
 ]

--- a/resources/metadata/Comments.tmPreferences
+++ b/resources/metadata/Comments.tmPreferences
@@ -5,7 +5,7 @@
     <key>name</key>
     <string>Comments</string>
     <key>scope</key>
-    <string>text.html.twig, meta.statement.twig, meta.expression.twig</string>
+    <string>meta.template.twig</string>
     <key>settings</key>
     <dict>
     <key>shellVariables</key>

--- a/resources/metadata/Indentation Rules.tmPreferences
+++ b/resources/metadata/Indentation Rules.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>text.html.twig</string>
+    <string>meta.template.twig</string>
     <key>settings</key>
     <dict>
         <key>decreaseIndentPattern</key>

--- a/resources/snippets/apply.sublime-snippet
+++ b/resources/snippets/apply.sublime-snippet
@@ -5,6 +5,6 @@
 {% endapply %}
 ]]></content>
 <tabTrigger>apply</tabTrigger>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 <description>Twig apply</description>
 </snippet>

--- a/resources/snippets/autoescape.sublime-snippet
+++ b/resources/snippets/autoescape.sublime-snippet
@@ -5,6 +5,6 @@
 {% endautoescape %}
 ]]></content>
 <tabTrigger>autoescape</tabTrigger>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 <description>Twig autoescape</description>
 </snippet>

--- a/resources/snippets/block.sublime-snippet
+++ b/resources/snippets/block.sublime-snippet
@@ -5,6 +5,6 @@
 {% endblock %}
 ]]></content>
 <tabTrigger>block</tabTrigger>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 <description>Twig block</description>
 </snippet>

--- a/resources/snippets/dump.sublime-snippet
+++ b/resources/snippets/dump.sublime-snippet
@@ -4,5 +4,5 @@
 ]]></content>
 <tabTrigger>dump</tabTrigger>
 <description>Twig dump</description>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 </snippet>

--- a/resources/snippets/embed.sublime-snippet
+++ b/resources/snippets/embed.sublime-snippet
@@ -5,6 +5,6 @@
 {% endembed %}
 ]]></content>
 <tabTrigger>embed</tabTrigger>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 <description>Twig embed</description>
 </snippet>

--- a/resources/snippets/extends.sublime-snippet
+++ b/resources/snippets/extends.sublime-snippet
@@ -3,6 +3,6 @@
 {% extends ${1} %}
 ]]></content>
 <tabTrigger>extends</tabTrigger>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 <description>Twig extends</description>
 </snippet>

--- a/resources/snippets/for.sublime-snippet
+++ b/resources/snippets/for.sublime-snippet
@@ -6,5 +6,5 @@
 ]]></content>
 <tabTrigger>for</tabTrigger>
 <description>Twig for</description>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 </snippet>

--- a/resources/snippets/if-else.sublime-snippet
+++ b/resources/snippets/if-else.sublime-snippet
@@ -8,5 +8,5 @@
 ]]></content>
 <tabTrigger>elif</tabTrigger>
 <description>Twig if-else</description>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 </snippet>

--- a/resources/snippets/if.sublime-snippet
+++ b/resources/snippets/if.sublime-snippet
@@ -6,5 +6,5 @@
 ]]></content>
 <tabTrigger>if</tabTrigger>
 <description>Twig if</description>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 </snippet>

--- a/resources/snippets/include.sublime-snippet
+++ b/resources/snippets/include.sublime-snippet
@@ -4,5 +4,5 @@
 ]]></content>
 <tabTrigger>include</tabTrigger>
 <description>Twig include</description>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 </snippet>

--- a/resources/snippets/macro.sublime-snippet
+++ b/resources/snippets/macro.sublime-snippet
@@ -5,6 +5,6 @@
 {% endmacro %}
 ]]></content>
 <tabTrigger>macro</tabTrigger>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 <description>Twig macro</description>
 </snippet>

--- a/resources/snippets/sandbox.sublime-snippet
+++ b/resources/snippets/sandbox.sublime-snippet
@@ -6,5 +6,5 @@
 ]]></content>
 <tabTrigger>sandbox</tabTrigger>
 <description>Twig sandbox</description>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 </snippet>

--- a/resources/snippets/set.sublime-snippet
+++ b/resources/snippets/set.sublime-snippet
@@ -3,6 +3,6 @@
 {% set ${1:variable} = ${2:value} %}
 ]]></content>
 <tabTrigger>set</tabTrigger>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 <description>Twig set</description>
 </snippet>

--- a/resources/snippets/verbatim.sublime-snippet
+++ b/resources/snippets/verbatim.sublime-snippet
@@ -5,6 +5,6 @@
 {% endverbatim %}
 ]]></content>
 <tabTrigger>verbatim</tabTrigger>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 <description>Twig verbatim</description>
 </snippet>

--- a/resources/snippets/with.sublime-snippet
+++ b/resources/snippets/with.sublime-snippet
@@ -5,6 +5,6 @@
 {% endwith %}${0}
 ]]></content>
 <tabTrigger>with</tabTrigger>
-<scope>text.html.twig - meta.expression.twig - meta.statement.twig</scope>
+<scope>meta.template.twig - meta.expression.twig - meta.statement.twig</scope>
 <description>Twig with</description>
 </snippet>

--- a/resources/syntax/CSS (Twig).sublime-syntax
+++ b/resources/syntax/CSS (Twig).sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 name: CSS (Twig)
-scope: source.css.twig meta.template.twig
+scope: source.css.twig
 version: 2
 
 extends: Packages/CSS/CSS.sublime-syntax
@@ -15,6 +15,10 @@ contexts:
     - meta_prepend: true
     - include: Twig.sublime-syntax#twig_embedded
     - include: Twig.sublime-syntax#comment
+
+  main:
+    - meta_prepend: true
+    - meta_scope: meta.template.twig
 
   string-content:
     - meta_prepend: true

--- a/resources/syntax/CSS (Twig).sublime-syntax
+++ b/resources/syntax/CSS (Twig).sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 name: CSS (Twig)
-scope: source.css.twig
+scope: source.css.twig meta.template.twig
 version: 2
 
 extends: Packages/CSS/CSS.sublime-syntax

--- a/resources/syntax/HTML (Twig).sublime-syntax
+++ b/resources/syntax/HTML (Twig).sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 name: HTML (Twig)
-scope: text.html.twig meta.template.twig
+scope: text.html.twig
 version: 2
 
 extends: Packages/HTML/HTML.sublime-syntax
@@ -17,6 +17,10 @@ contexts:
     - meta_prepend: true
     - include: Twig.sublime-syntax#twig_embedded
     - include: Twig.sublime-syntax#comment
+
+  main:
+    - meta_prepend: true
+    - meta_scope: meta.template.twig
 
   tag-attribute-value-content:
     - meta_prepend: true
@@ -35,7 +39,7 @@ contexts:
         3: keyword.declaration.cdata.html
         4: punctuation.definition.tag.begin.html
       pop: 1
-      embed: scope:source.css.twig meta.template.twig
+      embed: scope:source.css.twig
       embed_scope: meta.tag.sgml.cdata.html source.css.embedded.html
       escape: \]\]>
       escape_captures:
@@ -44,7 +48,7 @@ contexts:
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html
       pop: 1
-      embed: scope:source.css.twig meta.template.twig
+      embed: scope:source.css.twig
       embed_scope: source.css.embedded.html
       escape: '{{style_content_end}}'
       escape_captures:
@@ -56,14 +60,14 @@ contexts:
   tag-style-attribute-value:
     - match: \"
       scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
-      embed: scope:source.css.twig meta.template.twig#rule-list-body
+      embed: scope:source.css.twig#rule-list-body
       embed_scope: meta.string.html meta.interpolation.html source.css.embedded.html
       escape: \"
       escape_captures:
         0: meta.string.html string.quoted.double.html punctuation.definition.string.end.html
     - match: \'
       scope: meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
-      embed: scope:source.css.twig meta.template.twig#rule-list-body
+      embed: scope:source.css.twig#rule-list-body
       embed_scope: meta.string.html meta.interpolation.html source.css.embedded.html
       escape: \'
       escape_captures:
@@ -79,7 +83,7 @@ contexts:
         3: keyword.declaration.cdata.html
         4: punctuation.definition.tag.begin.html
       pop: 1
-      embed: scope:source.js.twig meta.template.twig
+      embed: scope:source.js.twig
       embed_scope: meta.tag.sgml.cdata.html source.js.embedded.html
       escape: \]\]>
       escape_captures:
@@ -88,7 +92,7 @@ contexts:
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html
       pop: 1
-      embed: scope:source.js.twig meta.template.twig
+      embed: scope:source.js.twig
       embed_scope: source.js.embedded.html
       escape: '{{script_content_end}}'
       escape_captures:

--- a/resources/syntax/HTML (Twig).sublime-syntax
+++ b/resources/syntax/HTML (Twig).sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 name: HTML (Twig)
-scope: text.html.twig
+scope: text.html.twig meta.template.twig
 version: 2
 
 extends: Packages/HTML/HTML.sublime-syntax
@@ -35,7 +35,7 @@ contexts:
         3: keyword.declaration.cdata.html
         4: punctuation.definition.tag.begin.html
       pop: 1
-      embed: scope:source.css.twig
+      embed: scope:source.css.twig meta.template.twig
       embed_scope: meta.tag.sgml.cdata.html source.css.embedded.html
       escape: \]\]>
       escape_captures:
@@ -44,7 +44,7 @@ contexts:
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html
       pop: 1
-      embed: scope:source.css.twig
+      embed: scope:source.css.twig meta.template.twig
       embed_scope: source.css.embedded.html
       escape: '{{style_content_end}}'
       escape_captures:
@@ -56,14 +56,14 @@ contexts:
   tag-style-attribute-value:
     - match: \"
       scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
-      embed: scope:source.css.twig#rule-list-body
+      embed: scope:source.css.twig meta.template.twig#rule-list-body
       embed_scope: meta.string.html meta.interpolation.html source.css.embedded.html
       escape: \"
       escape_captures:
         0: meta.string.html string.quoted.double.html punctuation.definition.string.end.html
     - match: \'
       scope: meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
-      embed: scope:source.css.twig#rule-list-body
+      embed: scope:source.css.twig meta.template.twig#rule-list-body
       embed_scope: meta.string.html meta.interpolation.html source.css.embedded.html
       escape: \'
       escape_captures:
@@ -79,7 +79,7 @@ contexts:
         3: keyword.declaration.cdata.html
         4: punctuation.definition.tag.begin.html
       pop: 1
-      embed: scope:source.js.twig
+      embed: scope:source.js.twig meta.template.twig
       embed_scope: meta.tag.sgml.cdata.html source.js.embedded.html
       escape: \]\]>
       escape_captures:
@@ -88,7 +88,7 @@ contexts:
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html
       pop: 1
-      embed: scope:source.js.twig
+      embed: scope:source.js.twig meta.template.twig
       embed_scope: source.js.embedded.html
       escape: '{{script_content_end}}'
       escape_captures:

--- a/resources/syntax/JavaScript (Twig).sublime-syntax
+++ b/resources/syntax/JavaScript (Twig).sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 name: JavaScript (Twig)
-scope: source.js.twig
+scope: source.js.twig meta.template.twig
 version: 2
 
 extends: Packages/JavaScript/JavaScript.sublime-syntax

--- a/resources/syntax/JavaScript (Twig).sublime-syntax
+++ b/resources/syntax/JavaScript (Twig).sublime-syntax
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 name: JavaScript (Twig)
-scope: source.js.twig meta.template.twig
+scope: source.js.twig
 version: 2
 
 extends: Packages/JavaScript/JavaScript.sublime-syntax
@@ -15,6 +15,10 @@ contexts:
     - meta_prepend: true
     - include: Twig.sublime-syntax#twig_embedded
     - include: Twig.sublime-syntax#comment
+
+  main:
+    - meta_prepend: true
+    - meta_scope: meta.template.twig
 
   string-content:
     - meta_prepend: true

--- a/resources/syntax/Twig.sublime-syntax
+++ b/resources/syntax/Twig.sublime-syntax
@@ -66,7 +66,7 @@ contexts:
       push: statement_block_meta
 
   statement_block_meta:
-    - meta_scope: meta.statement.twig
+    - meta_scope: meta.template.twig meta.statement.twig
     - clear_scopes: true
     - include: statement_body
 
@@ -88,7 +88,7 @@ contexts:
       push: expression_block_meta
 
   expression_block_meta:
-    - meta_scope: meta.expression.twig
+    - meta_scope: meta.template.twig meta.expression.twig
     - clear_scopes: true
     - include: expression_body
 


### PR DESCRIPTION
- This adds a common scope `meta.template.twig` which is applied to all variants (HTML, CSS, and JS) in addition to their own specific ones (`text.html.twig`, `source.css.twig`, and `source.js.twig`).
- This allows different settings to be applied to all variants at once, instead of needing to add a selector for each one separately.
- This also allows the snippets, key mappings, comments, and indentation rules to work for the CSS and JS variants instead of just the HTML one.