### PR TITLE
Fix the CSS syntax

### DIFF
--- a/resources/syntax/CSS (Twig).sublime-syntax
+++ b/resources/syntax/CSS (Twig).sublime-syntax
@@ -33,6 +33,7 @@ contexts:
     - meta_include_prototype: false
     - include: Twig.sublime-syntax#twig_embedded
     - include: Twig.sublime-syntax#comment
+    
   string-content:
     - meta_prepend: true
     - include: Twig.sublime-syntax#twig_embedded

--- a/resources/syntax/CSS (Twig).sublime-syntax
+++ b/resources/syntax/CSS (Twig).sublime-syntax
@@ -27,6 +27,12 @@ contexts:
     - include: Twig.sublime-syntax#twig_embedded
     - include: Twig.sublime-syntax#comment
 
+  at-rule-block-body:
+    # required until ST4173
+    - meta_prepend: true
+    - meta_include_prototype: false
+    - include: Twig.sublime-syntax#twig_embedded
+    - include: Twig.sublime-syntax#comment
   string-content:
     - meta_prepend: true
     - include: Twig.sublime-syntax#twig_embedded

--- a/resources/syntax/CSS (Twig).sublime-syntax
+++ b/resources/syntax/CSS (Twig).sublime-syntax
@@ -16,6 +16,17 @@ contexts:
     - include: Twig.sublime-syntax#twig_embedded
     - include: Twig.sublime-syntax#comment
 
+  main:
+    - meta_prepend: true
+    - meta_include_prototype: false
+    - include: Twig.sublime-syntax#twig_embedded
+    - include: Twig.sublime-syntax#comment
+
+  block-end:
+    - meta_append: true
+    - include: Twig.sublime-syntax#twig_embedded
+    - include: Twig.sublime-syntax#comment
+
   string-content:
     - meta_prepend: true
     - include: Twig.sublime-syntax#twig_embedded

--- a/resources/syntax/tests/syntax_test_css.css.twig
+++ b/resources/syntax/tests/syntax_test_css.css.twig
@@ -1,0 +1,22 @@
+/* SYNTAX TEST "Packages/Twig/resources/syntax/CSS (Twig).sublime-syntax" */
+
+/* Expression */
+   div {
+/* ^^^ meta.selector.css */
+/*     ^ punctuation.section.block.begin.css */
+       color: {{ blue|escape }} {# a comment #};
+/*            ^^^^^^^^^^^^^^^^^ meta.expression.twig */
+/*            ^^^^^^^^^^^^^^^^^ - meta.property-list.css */
+/*            ^^^^^^^^^^^^^^^^^ - meta.property-value.css */
+/*                              ^^^^^^^^^^^^^^^ comment.block.twig */
+   }
+/* ^ punctuation.section.block.end.css */
+
+/* Statement */
+   div {
+       {% block style %}{% endblock %}
+/*     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.statement.twig */
+
+       font-size: 24px;
+/*     ^^^^^^^^^ meta.property-name.css */
+   }


### PR DESCRIPTION
This fixes the CSS syntax since the base syntax does not include prototype in its top level contexts.

Tests are included.